### PR TITLE
[Fix] Fix MEP margins on mobile

### DIFF
--- a/assets/css/pages/landing/what-do.scss
+++ b/assets/css/pages/landing/what-do.scss
@@ -58,13 +58,13 @@
         color: #000;
         font-size: inherit;
         padding: .5em;
-        padding-right: 2.5em; 
+        padding-right: 2.5em;
         border: 0;
         margin: 0;
         border-radius: 3px;
         text-indent: 0.01px;
         text-overflow: '';
-        -webkit-appearance: button; 
+        -webkit-appearance: button;
     }
 
     .custom-dropdown::before,
@@ -74,7 +74,7 @@
         pointer-events: none;
     }
 
-    .custom-dropdown::after { 
+    .custom-dropdown::after {
         content: "\25BC";
         height: 1em;
         font-size: .625em;
@@ -84,7 +84,7 @@
         margin-top: -.5em;
     }
 
-    .custom-dropdown::before { 
+    .custom-dropdown::before {
         width: 2em;
         right: 0;
         top: 0;
@@ -260,13 +260,19 @@
         transform: translateX(-50%);
     }
 
+    .mep-list {
+        max-width: 100%;
+        flex: 0 0 100%;
+        margin: 0 auto;
+    }
+
     .mep-grid {
         display: flex;
         list-style-type: none;
         flex-flow: row wrap;
-        margin-left: -20px;
-        padding: 0 0 0 20px;
-        margin-right: -20px;
+        margin-left: 0;
+        padding: 0;
+        margin-right: 0;
     }
 
     .mep-grid .mep-item {
@@ -468,5 +474,5 @@
         .mep-main {
             flex-direction: column!important;
         }
-    }    
+    }
 }

--- a/templates/index/components/what-do.html.twig
+++ b/templates/index/components/what-do.html.twig
@@ -42,9 +42,9 @@
     </div>
     <div class="row icon-pair d-flex">
         <div class="col-3 col-lg-2 icon d-flex mobile-hide"></div>
-        <div class="col-9 col-sm-9 col-md-9 col-lg-7 text mobile-flex">
+        <div class="col-9 col-sm-9 col-md-9 col-lg-7 text mobile-flex mep-list">
             <span class="custom-dropdown big">
-                <select id="country-sel">    
+                <select id="country-sel">
                     <option value="" selected disabled hidden>Select country</option>
                     <option>Austria</option>
                     <option>Bulgaria</option>
@@ -89,7 +89,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -111,8 +111,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>           
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item bulgaria" onclick="">
@@ -133,7 +133,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -155,8 +155,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>           
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item germany" onclick="">
@@ -177,7 +177,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -199,8 +199,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>    
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item lithuania" onclick="">
@@ -221,7 +221,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -243,8 +243,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>            
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item portugal" onclick="">
@@ -265,7 +265,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -287,8 +287,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>           
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item germany" onclick="">
@@ -309,7 +309,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -331,8 +331,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>        
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item ireland" onclick="">
@@ -353,7 +353,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -363,8 +363,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption> 
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item romania" onclick="">
@@ -385,7 +385,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -407,8 +407,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>       
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item bulgaria" onclick="">
@@ -427,9 +427,9 @@
                                             <p>@Emil_Radev</p>
                                         </div>
                                     </div>
-                                </div> 
+                                </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -451,8 +451,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>           
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item italy" onclick="">
@@ -473,7 +473,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -495,8 +495,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>      
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item austria" onclick="">
@@ -517,7 +517,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -539,8 +539,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>      
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item germany" onclick="">
@@ -561,7 +561,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -583,8 +583,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption> 
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item malta" onclick="">
@@ -605,7 +605,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -627,8 +627,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>         
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item france" onclick="">
@@ -649,7 +649,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -671,8 +671,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>            
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item finland" onclick="">
@@ -693,7 +693,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -715,8 +715,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>        
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item italy" onclick="">
@@ -737,7 +737,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -759,8 +759,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>           
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item unitedkingdom" onclick="">
@@ -781,7 +781,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -803,8 +803,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>         
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item denmark" onclick="">
@@ -825,7 +825,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -847,8 +847,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>    
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item france" onclick="">
@@ -869,7 +869,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -891,8 +891,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>         
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item hungary" onclick="">
@@ -913,7 +913,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -923,8 +923,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>          
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item germany" onclick="">
@@ -945,7 +945,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -967,8 +967,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>          
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item sweden" onclick="">
@@ -989,7 +989,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1011,8 +1011,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>           
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item poland" onclick="">
@@ -1033,7 +1033,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1055,8 +1055,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>           
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item greece" onclick="">
@@ -1077,7 +1077,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1099,8 +1099,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>          
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item italy" onclick="">
@@ -1121,7 +1121,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1143,8 +1143,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>          
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item poland" onclick="">
@@ -1165,7 +1165,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1187,8 +1187,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>          
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item spain" onclick="">
@@ -1209,7 +1209,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1219,8 +1219,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>           
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item luxemburg" onclick="">
@@ -1241,7 +1241,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1263,8 +1263,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>           
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item france" onclick="">
@@ -1285,7 +1285,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1307,8 +1307,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>         
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item italy" onclick="">
@@ -1329,7 +1329,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1339,8 +1339,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>        
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item unitedkingdom" onclick="">
@@ -1361,7 +1361,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1383,8 +1383,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>            
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item sweden" onclick="">
@@ -1405,7 +1405,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1427,8 +1427,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>            
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item france" onclick="">
@@ -1449,7 +1449,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1471,8 +1471,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>            
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item czechrepublic" onclick="">
@@ -1493,7 +1493,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1515,8 +1515,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>           
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item germany" onclick="">
@@ -1537,7 +1537,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1547,8 +1547,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>           
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item romania" onclick="">
@@ -1569,7 +1569,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1579,8 +1579,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>            
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item spain" onclick="">
@@ -1601,7 +1601,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1611,8 +1611,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>            
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item unitedkingdom" onclick="">
@@ -1633,7 +1633,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1655,8 +1655,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>          
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item italy" onclick="">
@@ -1677,7 +1677,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1699,8 +1699,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>          
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item poland" onclick="">
@@ -1721,7 +1721,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1731,8 +1731,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>            
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item italy" onclick="">
@@ -1753,7 +1753,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1775,8 +1775,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>           
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item germany" onclick="">
@@ -1797,7 +1797,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1819,8 +1819,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>            
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item poland" onclick="">
@@ -1841,7 +1841,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1863,8 +1863,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>           
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item germany" onclick="">
@@ -1885,7 +1885,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1907,8 +1907,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>         
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item lithuania" onclick="">
@@ -1929,7 +1929,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1951,8 +1951,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>            
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                         <li class="mep-item france" onclick="">
@@ -1973,7 +1973,7 @@
                                     </div>
                                 </div>
                                 <figcaption>
-                                    <div class="mep-social"> 
+                                    <div class="mep-social">
                                         <div class="quoteslist-social">
                                             <ul class="essb_links_list">
                                                 <li class="essb_item essb_link_mep">
@@ -1995,8 +1995,8 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                    </div>      
-                                </figcaption>          
+                                    </div>
+                                </figcaption>
                             </figure>
                         </li>
                     </ul>


### PR DESCRIPTION
Margins on mobile for the MEP Cards was too wide

before:
![chrome_2018-06-18_14-17-47](https://user-images.githubusercontent.com/40218022/41535390-6939b688-7302-11e8-928f-dae083216a6d.png)


after:
![chrome_2018-06-18_14-16-04](https://user-images.githubusercontent.com/40218022/41535321-2cda4e8c-7302-11e8-957b-2605679b82c1.png)

